### PR TITLE
Resolve all PHPStan ignores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "brain/monkey": "^2.6",
     "mockery/mockery": "^1.4",
     "php-parallel-lint/php-parallel-lint": "^1.3",
+    "php-stubs/wp-cli-stubs": "^2.7",
     "phpunit/phpunit": "^9.5",
     "squizlabs/php_codesniffer": "^3.3",
     "symfony/polyfill-php80": "^1.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "383fe32d65334c5cde15e42f2ee30824",
+    "content-hash": "a5bd551459b17438deb7df6a8a56d2f4",
     "packages": [
         {
             "name": "composer/installers",
@@ -793,6 +793,50 @@
                 "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.1.0"
             },
             "time": "2022-11-09T05:33:25+00:00"
+        },
+        {
+            "name": "php-stubs/wp-cli-stubs",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wp-cli-stubs.git",
+                "reference": "428544fc3696273bfbb4cffe4ac88f5fed428fc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/428544fc3696273bfbb4cffe4ac88f5fed428fc8",
+                "reference": "428544fc3696273bfbb4cffe4ac88f5fed428fc8",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wp-cli-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress",
+                "wp-cli"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/v2.7.0"
+            },
+            "time": "2022-11-10T19:19:05+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,12 @@
 includes:
-    - phar://phpstan.phar/conf/bleedingEdge.neon
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
     level: 5
     paths:
-        - %currentWorkingDirectory%/classes/
+        - classes/
     bootstrapFiles:
-        - %currentWorkingDirectory%/tests/static-analysis/bootstrap.php
-        - %currentWorkingDirectory%/autoload.php
-    ignoreErrors:
-        - '#^Call to static method \S+\(\) on an unknown class WP_CLI\.$#'
-        - '#^Function WP_CLI\\.+ not found.$#'
+        - tests/static-analysis/bootstrap.php
+        - autoload.php
+    scanFiles:
+        - tests/static-analysis/stubs/php-cli-tools.php
+        - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php

--- a/tests/static-analysis/stubs/php-cli-tools.php
+++ b/tests/static-analysis/stubs/php-cli-tools.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace cli\progress;
+
+class Bar
+{
+    /**
+     * @param int    $increment The amount to increment by.
+     * @param string $msg       The text to display next to the Notifier. (optional)
+     */
+    public function tick($increment = 1, $msg = null) {}
+
+    public function finish() {}
+}


### PR DESCRIPTION
- add WP-CLI stubs
- and a bit of `php-cli-tools`

All ignores are gone 🍏

@chesio There is an error in WP-CLI
https://github.com/wp-cli/wp-cli/pull/5715
Before sending this PR I've fixed that on my local machine.